### PR TITLE
Use datastore to permanently store the comments

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -29,6 +29,12 @@
       <artifactId>gson</artifactId>
       <version>2.8.6</version>
     </dependency>
+
+    <dependency>
+    <groupId>com.google.appengine</groupId>
+    <artifactId>appengine-api-1.0-sdk</artifactId>
+    <version>1.9.59</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -14,6 +14,9 @@
 
 package com.google.sps.servlets;
 
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
 import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -54,9 +57,14 @@ public class DataServlet extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String comment = request.getParameter("comment-input");
-    messages.add(comment);
 
-    // Redirects to the current page to see new comment added.
+    Entity messageEntity = new Entity("Message");
+    messageEntity.setProperty("comment", comment);
+    
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    datastore.put(messageEntity);
+
+    // Redirects to the bottom of the current page to see new comment added.
     response.sendRedirect("/index.html#connect-container");
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -28,12 +28,6 @@ import javax.servlet.http.HttpServletResponse;
 /** Servlet that writes and returns comments data */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
-  private ArrayList<String> messages;
-
-  @Override
-  public void init() {
-    this.messages = new ArrayList<>();
-  }
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -28,6 +28,12 @@ import javax.servlet.http.HttpServletResponse;
 /** Servlet that writes and returns comments data */
 @WebServlet("/data")
 public class DataServlet extends HttpServlet {
+  private ArrayList<String> messages;
+
+  @Override
+  public void init() {
+    this.messages = new ArrayList<>();
+  }
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -36,12 +36,6 @@ public class DataServlet extends HttpServlet {
   // Constants for Entity instances.
   private static final String MESSAGE_ENTITY = "Message";
   private static final String COMMENT_PROPERTY = "comment";
-  
-
-  @Override
-  public void init() {
-    this.messages = new ArrayList<>();
-  }
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -36,8 +36,6 @@ public class DataServlet extends HttpServlet {
   // Constants for Entity instances.
   private static final String MESSAGE_ENTITY = "Message";
   private static final String COMMENT_PROPERTY = "comment";
-
-  private ArrayList<String> messages;
   
 
   @Override


### PR DESCRIPTION
Before, comments would be lost if the development server is closed. With this change, comments are stored as entities in DataStore. The next pull request will deal with loading the comments from the DataStore in doGet(). With this change, comments temporarily do not appear on the webpage.

Admin Page with added comments: https://screenshot.googleplex.com/Z3mu9rUUAko