### PR TITLE
Allow users to display their nickname rather than their email address for their comments.

### DIFF
--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -50,9 +50,9 @@
     </dependency>
     
     <dependency>
-    <groupId>com.google.appengine</groupId>
-    <artifactId>appengine-api-1.0-sdk</artifactId>
-    <version>1.9.59</version>
+      <groupId>com.google.appengine</groupId>
+      <artifactId>appengine-api-1.0-sdk</artifactId>
+      <version>1.9.59</version>
     </dependency>
   </dependencies>
 

--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -48,12 +48,6 @@
       <version>1.6.2</version>
       <scope>provided</scope>
     </dependency>
-    
-    <dependency>
-      <groupId>com.google.appengine</groupId>
-      <artifactId>appengine-api-1.0-sdk</artifactId>
-      <version>1.9.59</version>
-    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/pom.xml
+++ b/portfolio/pom.xml
@@ -48,6 +48,12 @@
       <version>1.6.2</version>
       <scope>provided</scope>
     </dependency>
+    
+    <dependency>
+    <groupId>com.google.appengine</groupId>
+    <artifactId>appengine-api-1.0-sdk</artifactId>
+    <version>1.9.59</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -10,8 +10,9 @@ public abstract class Comment {
    * Creates a commment instance containing its {@code id},
    * {@code text}, and {@code timestamp}. 
    */
-  public static Comment create(long id, String text, long timestamp, String name, String email) {
-    return new AutoValue_Comment(id, text, timestamp, name, email);
+   //TODO: FIx column length of method signature.
+  public static Comment create(long id, String text, long timestamp, String name, String email, String nickname) {
+    return new AutoValue_Comment(id, text, timestamp, name, email, nickname);
   }
 
   abstract long id();
@@ -23,5 +24,7 @@ public abstract class Comment {
   abstract String name();
 
   abstract String email();
+
+  abstract String nickname();
 }
 

--- a/portfolio/src/main/java/com/google/sps/data/Comment.java
+++ b/portfolio/src/main/java/com/google/sps/data/Comment.java
@@ -10,8 +10,8 @@ public abstract class Comment {
    * Creates a commment instance containing its {@code id},
    * {@code text}, and {@code timestamp}. 
    */
-   //TODO: FIx column length of method signature.
-  public static Comment create(long id, String text, long timestamp, String name, String email, String nickname) {
+  public static Comment create(long id, String text, long timestamp, 
+      String name, String email, String nickname) {
     return new AutoValue_Comment(id, text, timestamp, name, email, nickname);
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -86,8 +86,6 @@ public class DataServlet extends HttpServlet {
       String text = (String) comment.getProperty(COMMENT_TEXT);
       long timestamp = (long) comment.getProperty(COMMENT_TIMESTAMP);
       String name = (String) comment.getProperty(COMMENT_NAME);
-      // TODO: Remove email property.
-      String email = (String) comment.getProperty(COMMENT_EMAIL);
       String nickname = (String) comment.getProperty(COMMENT_NICKNAME);
 
       comments.add(Comment.create(id, text, timestamp, name, email, nickname));
@@ -117,7 +115,7 @@ public class DataServlet extends HttpServlet {
     String email = (String) HomeServlet.userEmail;
     String nickname = (String) HomeServlet.nickname;
     System.out.println(nickname);
-    // String nickname = "amy";
+
     if (name.isEmpty()) {
       name = ANONYMOUS;
     }
@@ -127,8 +125,6 @@ public class DataServlet extends HttpServlet {
     commentEntity.setProperty(COMMENT_TIMESTAMP, timestamp);
     commentEntity.setProperty(COMMENT_NAME, name);
     commentEntity.setProperty(COMMENT_LENGTH, text.length());
-    // TODO: Remove email property.
-    commentEntity.setProperty(COMMENT_EMAIL, email);  
     commentEntity.setProperty(COMMENT_NICKNAME, nickname);
     
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -90,7 +90,15 @@ public class DataServlet extends HttpServlet {
       String text = (String) comment.getProperty(COMMENT_TEXT);
       long timestamp = (long) comment.getProperty(COMMENT_TIMESTAMP);
       String name = (String) comment.getProperty(COMMENT_NAME);
-      String nickname = (String) comment.getProperty(COMMENT_NICKNAME);
+      System.out.println(comment.getProperty(COMMENT_NICKNAME));
+      String nickname;
+      if (comment.getProperty(COMMENT_NICKNAME) == null) {
+        nickname = "nothing";
+        System.out.println("nothing");
+        System.out.println(HomeServlet.userEmail);
+      } else {
+        nickname = (String) comment.getProperty(COMMENT_NICKNAME);
+      }
       String email = (String) comment.getProperty(COMMENT_EMAIL);
 
       comments.add(Comment.create(id, text, timestamp, name, email, nickname));
@@ -116,11 +124,21 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     UserService userService = UserServiceFactory.getUserService();
     String email = userService.getCurrentUser().getEmail();
+    System.out.println(email);
+    if (email == null) {
+      console.log("null email");
+      email = HomeServlet.userEmail;
+    }
 
     String text = request.getParameter(COMMENT_INPUT);
     long timestamp = System.currentTimeMillis();
     String name = (String) request.getParameter(COMMENT_NAME);
-    String nickname = getUserNickname(userService.getCurrentUser().getUserId());
+    String nickname = "test";//getUserNickname(userService.getCurrentUser().getUserId());
+    System.out.println(nickname);
+    if (nickname == null) {
+      nickname = "";
+      System.out.println("in if statement.");
+    }
 
     if (name.isEmpty()) {
       name = ANONYMOUS_AUTHOR;
@@ -157,5 +175,4 @@ public class DataServlet extends HttpServlet {
     String nickname = (String) entity.getProperty(COMMENT_NICKNAME);
     return nickname;
   }
-
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -46,6 +46,7 @@ public class DataServlet extends HttpServlet {
   private static final String COMMENT_NAME = "name";
   private static final String COMMENT_LENGTH = "length";
   private static final String COMMENT_EMAIL = "email";
+  private static final String COMMENT_NICKNAME = "nickname";
   
   private static final String ANONYMOUS = "anonymous";
   
@@ -85,9 +86,11 @@ public class DataServlet extends HttpServlet {
       String text = (String) comment.getProperty(COMMENT_TEXT);
       long timestamp = (long) comment.getProperty(COMMENT_TIMESTAMP);
       String name = (String) comment.getProperty(COMMENT_NAME);
+      // TODO: Remove email property.
       String email = (String) comment.getProperty(COMMENT_EMAIL);
+      String nickname = (String) comment.getProperty(COMMENT_NICKNAME);
 
-      comments.add(Comment.create(id, text, timestamp, name, email));
+      comments.add(Comment.create(id, text, timestamp, name, email, nickname));
       commentCounter++;
     } 
     
@@ -112,7 +115,9 @@ public class DataServlet extends HttpServlet {
     long timestamp = System.currentTimeMillis();
     String name = request.getParameter(COMMENT_NAME);
     String email = (String) HomeServlet.userEmail;
-
+    String nickname = (String) HomeServlet.nickname;
+    System.out.println(nickname);
+    // String nickname = "amy";
     if (name.isEmpty()) {
       name = ANONYMOUS;
     }
@@ -122,7 +127,9 @@ public class DataServlet extends HttpServlet {
     commentEntity.setProperty(COMMENT_TIMESTAMP, timestamp);
     commentEntity.setProperty(COMMENT_NAME, name);
     commentEntity.setProperty(COMMENT_LENGTH, text.length());
-    commentEntity.setProperty(COMMENT_EMAIL, email);
+    // TODO: Remove email property.
+    commentEntity.setProperty(COMMENT_EMAIL, email);  
+    commentEntity.setProperty(COMMENT_NICKNAME, nickname);
     
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     datastore.put(commentEntity);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -81,8 +81,8 @@ public class DataServlet extends HttpServlet {
       if (commentCounter == maxComments) {
         break;
       }
+      
       long id = comment.getKey().getId();
-
       String text = (String) comment.getProperty(COMMENT_TEXT);
       long timestamp = (long) comment.getProperty(COMMENT_TIMESTAMP);
       String name = (String) comment.getProperty(COMMENT_NAME);
@@ -114,7 +114,6 @@ public class DataServlet extends HttpServlet {
     String name = request.getParameter(COMMENT_NAME);
     String email = (String) HomeServlet.userEmail;
     String nickname = (String) HomeServlet.nickname;
-    System.out.println(nickname);
 
     if (name.isEmpty()) {
       name = ANONYMOUS;

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -134,7 +134,6 @@ public class DataServlet extends HttpServlet {
     if (name.isEmpty()) {
       name = ANONYMOUS_AUTHOR;
     }
-    
     Entity commentEntity = new Entity(COMMENT_ENTITY);
     commentEntity.setProperty(COMMENT_TEXT, text);
     commentEntity.setProperty(COMMENT_TIMESTAMP, timestamp);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -58,6 +58,9 @@ public class DataServlet extends HttpServlet {
   private static final String NEWEST_FIRST = "Newest First";
   private static final String LONGEST_FIRST = "Longest First";
 
+  private static final String ID = "ID";
+  private static final String USER_INFO = "userInfo";
+
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     int maxComments = Integer.parseInt(request.getParameter(COMMENT_AMOUNT));
@@ -117,8 +120,7 @@ public class DataServlet extends HttpServlet {
     String text = request.getParameter(COMMENT_INPUT);
     long timestamp = System.currentTimeMillis();
     String name = (String) request.getParameter(COMMENT_NAME);
-    String email = (String) HomeServlet.userEmail;
-    String nickname = (String) HomeServlet.nickname;
+    String nickname = getUserNickname(userService.getCurrentUser().getUserId());
 
     if (name.isEmpty()) {
       name = ANONYMOUS_AUTHOR;
@@ -137,6 +139,23 @@ public class DataServlet extends HttpServlet {
 
     // Redirects to the bottom of the current page to see new comment added.
     response.sendRedirect(BOTTOM_OF_PAGE);
+  }
+
+  /**
+   * Returns the nickname of the user with id, or empty String if the user has not set a nickname.
+   */
+  private String getUserNickname(String id) {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Query query =
+        new Query(USER_INFO)
+            .setFilter(new Query.FilterPredicate(ID, Query.FilterOperator.EQUAL, id));
+    PreparedQuery results = datastore.prepare(query);
+    Entity entity = results.asSingleEntity();
+    if (entity == null) {
+      return "";
+    }
+    String nickname = (String) entity.getProperty(COMMENT_NICKNAME);
+    return nickname;
   }
 
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -81,12 +81,13 @@ public class DataServlet extends HttpServlet {
       if (commentCounter == maxComments) {
         break;
       }
-      
+
       long id = comment.getKey().getId();
       String text = (String) comment.getProperty(COMMENT_TEXT);
       long timestamp = (long) comment.getProperty(COMMENT_TIMESTAMP);
       String name = (String) comment.getProperty(COMMENT_NAME);
       String nickname = (String) comment.getProperty(COMMENT_NICKNAME);
+      String email = (String) comment.getProperty(COMMENT_EMAIL);
 
       comments.add(Comment.create(id, text, timestamp, name, email, nickname));
       commentCounter++;
@@ -124,6 +125,7 @@ public class DataServlet extends HttpServlet {
     commentEntity.setProperty(COMMENT_TIMESTAMP, timestamp);
     commentEntity.setProperty(COMMENT_NAME, name);
     commentEntity.setProperty(COMMENT_LENGTH, text.length());
+    commentEntity.setProperty(COMMENT_EMAIL, email);
     commentEntity.setProperty(COMMENT_NICKNAME, nickname);
     
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -74,7 +74,7 @@ public class DataServlet extends HttpServlet {
     int maxComments = Integer.parseInt(request.getParameter(COMMENT_AMOUNT));
     String sort = request.getParameter(SORT);
 
-    // Move addSort() code to its own method.
+    // TODO: Move addSort() code to its own method.
     Query query = new Query(COMMENT_ENTITY);
     if (sort.equals(OLDEST_FIRST)) {
       query.addSort(COMMENT_TIMESTAMP, SortDirection.ASCENDING);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -124,7 +124,6 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     UserService userService = UserServiceFactory.getUserService();
     String email = userService.getCurrentUser().getEmail();
-
     String text = request.getParameter(COMMENT_INPUT);
     long timestamp = System.currentTimeMillis();
     String name = (String) request.getParameter(COMMENT_NAME);

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -84,7 +84,6 @@ public class DataServlet extends HttpServlet {
       query.addSort(COMMENT_LENGTH, SortDirection.DESCENDING);
     }
 
-    this.datastore = DatastoreServiceFactory.getDatastoreService();
     PreparedQuery results = this.datastore.prepare(query);
 
     ArrayList<Comment> comments = new ArrayList<>();
@@ -142,7 +141,6 @@ public class DataServlet extends HttpServlet {
     commentEntity.setProperty(COMMENT_EMAIL, email);
     commentEntity.setProperty(COMMENT_NICKNAME, nickname);
     
-    this.datastore = DatastoreServiceFactory.getDatastoreService();
     this.datastore.put(commentEntity);
 
     // Redirects to the bottom of the current page to see new comment added.

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -129,7 +129,7 @@ public class DataServlet extends HttpServlet {
     String text = request.getParameter(COMMENT_INPUT);
     long timestamp = System.currentTimeMillis();
     String name = (String) request.getParameter(COMMENT_NAME);
-    String nickname = HomeServlet.getUserNickname();
+    String nickname = HomeServlet.userNickname();
 
     if (name.isEmpty()) {
       name = ANONYMOUS_AUTHOR;

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -115,7 +115,6 @@ public class DataServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     UserService userService = UserServiceFactory.getUserService();
     String email = userService.getCurrentUser().getEmail();
-    System.out.println(email);
 
     String text = request.getParameter(COMMENT_INPUT);
     long timestamp = System.currentTimeMillis();

--- a/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/DataServlet.java
@@ -90,15 +90,7 @@ public class DataServlet extends HttpServlet {
       String text = (String) comment.getProperty(COMMENT_TEXT);
       long timestamp = (long) comment.getProperty(COMMENT_TIMESTAMP);
       String name = (String) comment.getProperty(COMMENT_NAME);
-      System.out.println(comment.getProperty(COMMENT_NICKNAME));
-      String nickname;
-      if (comment.getProperty(COMMENT_NICKNAME) == null) {
-        nickname = "nothing";
-        System.out.println("nothing");
-        System.out.println(HomeServlet.userEmail);
-      } else {
-        nickname = (String) comment.getProperty(COMMENT_NICKNAME);
-      }
+      String nickname = (String) comment.getProperty(COMMENT_NICKNAME);
       String email = (String) comment.getProperty(COMMENT_EMAIL);
 
       comments.add(Comment.create(id, text, timestamp, name, email, nickname));
@@ -125,20 +117,11 @@ public class DataServlet extends HttpServlet {
     UserService userService = UserServiceFactory.getUserService();
     String email = userService.getCurrentUser().getEmail();
     System.out.println(email);
-    if (email == null) {
-      console.log("null email");
-      email = HomeServlet.userEmail;
-    }
 
     String text = request.getParameter(COMMENT_INPUT);
     long timestamp = System.currentTimeMillis();
     String name = (String) request.getParameter(COMMENT_NAME);
-    String nickname = "test";//getUserNickname(userService.getCurrentUser().getUserId());
-    System.out.println(nickname);
-    if (nickname == null) {
-      nickname = "";
-      System.out.println("in if statement.");
-    }
+    String nickname = HomeServlet.getUserNickname();
 
     if (name.isEmpty()) {
       name = ANONYMOUS_AUTHOR;
@@ -157,22 +140,5 @@ public class DataServlet extends HttpServlet {
 
     // Redirects to the bottom of the current page to see new comment added.
     response.sendRedirect(BOTTOM_OF_PAGE);
-  }
-
-  /**
-   * Returns the nickname of the user with id, or empty String if the user has not set a nickname.
-   */
-  private String getUserNickname(String id) {
-    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    Query query =
-        new Query(USER_INFO)
-            .setFilter(new Query.FilterPredicate(ID, Query.FilterOperator.EQUAL, id));
-    PreparedQuery results = datastore.prepare(query);
-    Entity entity = results.asSingleEntity();
-    if (entity == null) {
-      return "";
-    }
-    String nickname = (String) entity.getProperty(COMMENT_NICKNAME);
-    return nickname;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
@@ -1,5 +1,10 @@
 package com.google.sps.servlets;
 
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
 import java.io.IOException;
@@ -11,6 +16,7 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/login")
 public class HomeServlet extends HttpServlet {
   public static String userEmail;
+  public static String nickname;
   private static final String HOME = "/";
 
   @Override
@@ -30,7 +36,7 @@ public class HomeServlet extends HttpServlet {
     }
 
     // If user has not set a nickname, redirect to nickname page
-    String nickname = getUserNickname(userService.getCurrentUser().getUserId());
+    nickname = getUserNickname(userService.getCurrentUser().getUserId());
     if (nickname == null) {
       response.sendRedirect("/nickname");
       return;

--- a/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
@@ -73,7 +73,7 @@ public class HomeServlet extends HttpServlet {
     return nickname;
   }
 
-  /** Returns the nickname of the current user when called in other classes. */
+  /** Returns the nickname of the current user when needed in other classes. */
   public static String getUserNickname() {
     return nickname;
   }

--- a/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
@@ -24,6 +24,9 @@ public class HomeServlet extends HttpServlet {
   private static final String ADMIN_EMAIL = "amytn@google.com";
   private static final String NICKNAME_SERVLET = "/nickname";
 
+  // Email and nickname of the current user. Since there is only one 
+  // current User at a time, there should only be one email and nickname
+  // at a time.
   private static String userEmail;
   private static String nickname;
 

--- a/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
@@ -35,7 +35,7 @@ public class HomeServlet extends HttpServlet {
     }
 
     // If user has not set a nickname, redirect to nickname page
-    nickname = getUserNickname(userService.getCurrentUser().getUserId());
+    String nickname = getUserNickname(userService.getCurrentUser().getUserId());
     if (nickname == null) {
       response.sendRedirect("/nickname");
       return;
@@ -45,7 +45,7 @@ public class HomeServlet extends HttpServlet {
     String logoutUrl = userService.createLogoutURL(HOME_PATH);
 
     response.getWriter().println("<p>Hello " + nickname + "!</p>");
-    response.getWriter().println("<button onclick=\"changeNickname()\">Change nickname</button>");
+    response.getWriter().println("<button onclick=\"changeNickname();\">Change nickname</button>");
     response.getWriter().println("<p>Logout <a href=\"" + logoutUrl + "\">here</a>.</p>");
   }
 
@@ -53,7 +53,7 @@ public class HomeServlet extends HttpServlet {
   private String getUserNickname(String id) {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Query query =
-        new Query("UserInfo")
+        new Query("userInfo")
             .setFilter(new Query.FilterPredicate("id", Query.FilterOperator.EQUAL, id));
     PreparedQuery results = datastore.prepare(query);
     Entity entity = results.asSingleEntity();

--- a/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
@@ -18,8 +18,8 @@ public class HomeServlet extends HttpServlet {
   private static final String HOME_PATH = "/";
   // Hard-coded email of webpage admin.
   private static final String adminEmail = "amytn@google.com";
-  public static String userEmail;
-  public static String nickname;
+  private static String userEmail;
+  private static String nickname;
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -31,7 +31,7 @@ public class HomeServlet extends HttpServlet {
     if (!userService.isUserLoggedIn()) {
       String loginUrl = userService.createLoginURL(HOME_PATH);
 
-      response.getWriter().println("<style>form {display:none;}</style>");
+      response.getWriter().println("<style>#comment-form {display:none;}</style>");
       response.getWriter().println("<p>Hello friend.</p>");
       response.getWriter().println("<p>Please log in to Add a comment.</p>");
       response.getWriter().println("<p>Login <a href=\"" + loginUrl + "\">here</a>.</p>");
@@ -70,6 +70,11 @@ public class HomeServlet extends HttpServlet {
       return null;
     }
     String nickname = (String) entity.getProperty("nickname");
+    return nickname;
+  }
+
+  /** Returns the nickname of the current user when called in other classes. */
+  public static String getUserNickname() {
     return nickname;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
@@ -16,6 +16,8 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/login")
 public class HomeServlet extends HttpServlet {
   private static final String HOME_PATH = "/";
+  // Hard-coded email of webpage admin.
+  private static final String adminEmail = "amytn@google.com";
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -46,6 +48,11 @@ public class HomeServlet extends HttpServlet {
 
     response.getWriter().println("<p>Hello " + nickname + "!</p>");
     response.getWriter().println("<button onclick=\"changeNickname();\">Change nickname</button>");
+    
+    if (userEmail.equals(adminEmail)) {
+      response.getWriter().println("<button onclick=\"deleteAllComments();\">Delete all Comments</button>");
+    }
+
     response.getWriter().println("<p>Logout <a href=\"" + logoutUrl + "\">here</a>.</p>");
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
@@ -82,8 +82,13 @@ public class HomeServlet extends HttpServlet {
     return optionalEntity.map(entity->(String)entity.getProperty(COMMENT_NICKNAME));
   }
 
-  /** Returns the nickname of the current user when needed in other classes. */
-  public static String getUserNickname() {
+  /** 
+   * Returns the nickname of the current user when needed in other classes.
+   * 
+   * <p>This method is only called after a user sets a nickname so it should
+   * never return null.
+   */
+  public static String userNickname() {
     return nickname;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
@@ -16,6 +16,9 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/login")
 public class HomeServlet extends HttpServlet {
   private static final String HOME_PATH = "/";
+  private static final String USER_INFO = "userInfo";
+  private static final String ID = "id";
+  private static final String COMMENT_NICKNAME = "nickname";
   // Hard-coded email of webpage admin.
   private static final String adminEmail = "amytn@google.com";
   private static String userEmail;
@@ -63,14 +66,14 @@ public class HomeServlet extends HttpServlet {
   private String getUserNickname(String id) {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Query query =
-        new Query("userInfo")
-            .setFilter(new Query.FilterPredicate("id", Query.FilterOperator.EQUAL, id));
+        new Query(USER_INFO)
+            .setFilter(new Query.FilterPredicate(ID, Query.FilterOperator.EQUAL, id));
     PreparedQuery results = datastore.prepare(query);
     Entity entity = results.asSingleEntity();
     if (entity == null) {
       return null;
     }
-    String nickname = (String) entity.getProperty("nickname");
+    String nickname = (String) entity.getProperty(COMMENT_NICKNAME);
     return nickname;
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
@@ -51,6 +51,7 @@ public class HomeServlet extends HttpServlet {
     response.getWriter().println("<p>Hello " + nickname + "!</p>");
     response.getWriter().println("<button onclick=\"changeNickname();\">Change nickname</button>");
     
+    // Allows the user to delete all of the comments only if the email is the same as the admin email.
     if (userEmail.equals(adminEmail)) {
       response.getWriter().println("<button onclick=\"deleteAllComments();\">Delete all Comments</button>");
     }

--- a/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
@@ -45,13 +45,13 @@ public class HomeServlet extends HttpServlet {
     }
 
     // If user has not set a nickname, redirect to nickname page
-    Optional<String> optionalNickname = getUserNickname(userService.getCurrentUser().getUserId());
-    if (!optionalNickname.isPresent()) {
+    Optional<String> nickname = getUserNickname(userService.getCurrentUser().getUserId());
+    if (!nickname.isPresent()) {
       response.sendRedirect(NICKNAME_SERVLET);
       return;    
     }
     
-    nickname = optionalNickname.get();
+    nickname = nickname.get();
     userEmail = userService.getCurrentUser().getEmail();
     String logoutUrl = userService.createLogoutURL(HOME_PATH);
 

--- a/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
@@ -46,6 +46,7 @@ public class HomeServlet extends HttpServlet {
     String logoutUrl = userService.createLogoutURL(HOME);
 
     response.getWriter().println("<p>Hello " + nickname + "!</p>");
+    response.getWriter().println("<button onclick=\"changeNickname()\">Change nickname</button>");
     response.getWriter().println("<p>Logout <a href=\"" + logoutUrl + "\">here</a>.</p>");
   }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
@@ -76,7 +76,6 @@ public class HomeServlet extends HttpServlet {
     Optional<Entity> optionalEntity = Optional.ofNullable(results.asSingleEntity());
     
     return optionalEntity.map(entity->(String)entity.getProperty(COMMENT_NICKNAME));
-
   }
 
   /** Returns the nickname of the current user when needed in other classes. */

--- a/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
@@ -20,7 +20,9 @@ public class HomeServlet extends HttpServlet {
   private static final String ID = "id";
   private static final String COMMENT_NICKNAME = "nickname";
   // Hard-coded email of webpage admin.
-  private static final String adminEmail = "amytn@google.com";
+  private static final String ADMIN_EMAIL = "amytn@google.com";
+  private static final String NICKNAME_SERVLET = "/nickname";
+
   private static String userEmail;
   private static String nickname;
 
@@ -44,7 +46,7 @@ public class HomeServlet extends HttpServlet {
     // If user has not set a nickname, redirect to nickname page
     nickname = getUserNickname(userService.getCurrentUser().getUserId());
     if (nickname == null) {
-      response.sendRedirect("/nickname");
+      response.sendRedirect(NICKNAME_SERVLET);
       return;
     }
 
@@ -55,7 +57,7 @@ public class HomeServlet extends HttpServlet {
     response.getWriter().println("<button onclick=\"changeNickname();\">Change nickname</button>");
     
     // Allows the user to delete all of the comments only if the email is the same as the admin email.
-    if (userEmail.equals(adminEmail)) {
+    if (userEmail.equals(ADMIN_EMAIL)) {
       response.getWriter().println("<button onclick=\"deleteAllComments();\">Delete all Comments</button>");
     }
 

--- a/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
@@ -66,7 +66,8 @@ public class HomeServlet extends HttpServlet {
     response.getWriter().println("<p>Logout <a href=\"" + logoutUrl + "\">here</a>.</p>");
   }
 
-  /** Returns the nickname of the user with id, or null if the user has not set a nickname. */
+  /** Returns an Optional object containing the nickname of the user with {@code id},
+   * or an empty Optional if the user has not set a nickname. */
   private Optional<String> getUserNickname(String id) {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Query query =

--- a/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/HomeServlet.java
@@ -18,6 +18,8 @@ public class HomeServlet extends HttpServlet {
   private static final String HOME_PATH = "/";
   // Hard-coded email of webpage admin.
   private static final String adminEmail = "amytn@google.com";
+  public static String userEmail;
+  public static String nickname;
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -37,13 +39,13 @@ public class HomeServlet extends HttpServlet {
     }
 
     // If user has not set a nickname, redirect to nickname page
-    String nickname = getUserNickname(userService.getCurrentUser().getUserId());
+    nickname = getUserNickname(userService.getCurrentUser().getUserId());
     if (nickname == null) {
       response.sendRedirect("/nickname");
       return;
     }
 
-    String userEmail = userService.getCurrentUser().getEmail();
+    userEmail = userService.getCurrentUser().getEmail();
     String logoutUrl = userService.createLogoutURL(HOME_PATH);
 
     response.getWriter().println("<p>Hello " + nickname + "!</p>");

--- a/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
@@ -16,6 +16,8 @@ import javax.servlet.http.HttpServletResponse;
 
 @WebServlet("/nickname")
 public class NicknameServlet extends HttpServlet {
+  private static final String NICKNAME = "nickname";
+  
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -56,7 +58,7 @@ public class NicknameServlet extends HttpServlet {
     // The put() function automatically inserts new data or updates existing data based on ID
     datastore.put(entity);
 
-    response.sendRedirect("/home");
+    response.sendRedirect("/");
   }
 
   /**

--- a/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
@@ -22,7 +22,15 @@ public class NicknameServlet extends HttpServlet {
   private static final String USER_INFO = "userInfo";
 
   private static final String BOTTOM_OF_PAGE = "/index.html#connect-container";
+
+  private static UserService userService;
+  private static DatastoreService datastore;
   
+  @Override
+  public void init() {
+    this.userService = UserServiceFactory.getUserService();
+    this.datastore = DatastoreServiceFactory.getDatastoreService();
+  }
 
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -30,7 +38,7 @@ public class NicknameServlet extends HttpServlet {
     PrintWriter out = response.getWriter();
     out.println("<h1>Set Nickname</h1>");
 
-    UserService userService = UserServiceFactory.getUserService();
+    this.userService = UserServiceFactory.getUserService();
     if (!userService.isUserLoggedIn()) {
       String loginUrl = userService.createLoginURL("/nickname");
       out.println("<p>Login <a href=\"" + loginUrl + "\">here</a>.</p>");
@@ -49,21 +57,21 @@ public class NicknameServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    UserService userService = UserServiceFactory.getUserService();
-    if (!userService.isUserLoggedIn()) {
+    this.userService = UserServiceFactory.getUserService();
+    if (!this.userService.isUserLoggedIn()) {
       response.sendRedirect("/nickname");
       return;
     }
 
     String nickname = request.getParameter(NICKNAME);
-    String id = userService.getCurrentUser().getUserId();
+    String id = this.userService.getCurrentUser().getUserId();
 
-    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    this.datastore = DatastoreServiceFactory.getDatastoreService();
     Entity entity = new Entity(USER_INFO, id);
     entity.setProperty(ID, id);
     entity.setProperty(NICKNAME, nickname);
     // The put() function automatically inserts new data or updates existing data based on ID.
-    datastore.put(entity);
+    this.datastore.put(entity);
 
     response.sendRedirect(BOTTOM_OF_PAGE);
   }
@@ -71,11 +79,11 @@ public class NicknameServlet extends HttpServlet {
   /** Returns an Optional object containing the nickname of the user with {@code id},
    * or an empty Optional if the user has not set a nickname. */
   private Optional<String> getUserNickname(String id) {
-    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    this.datastore = DatastoreServiceFactory.getDatastoreService();
     Query query =
         new Query(USER_INFO)
             .setFilter(new Query.FilterPredicate(ID, Query.FilterOperator.EQUAL, id));
-    PreparedQuery results = datastore.prepare(query);
+    PreparedQuery results = this.datastore.prepare(query);
     Optional<Entity> optionalEntity = Optional.ofNullable(results.asSingleEntity());
     
     return optionalEntity.map(entity->(String)entity.getProperty(NICKNAME));

--- a/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
@@ -39,13 +39,13 @@ public class NicknameServlet extends HttpServlet {
     out.println("<h1>Set Nickname</h1>");
 
     this.userService = UserServiceFactory.getUserService();
-    if (!userService.isUserLoggedIn()) {
+    if (!this.userService.isUserLoggedIn()) {
       String loginUrl = userService.createLoginURL("/nickname");
       out.println("<p>Login <a href=\"" + loginUrl + "\">here</a>.</p>");
       return;
     }
 
-    String nickname = getUserNickname(userService.getCurrentUser().getUserId()).orElse("");
+    String nickname = getUserNickname(this.userService.getCurrentUser().getUserId()).orElse("");
     response.getWriter().println("<style>#comment-form {display:none;}</style>");
     out.println("<p>Set your nickname here:</p>");
     out.println("<form method=\"POST\" action=\"/nickname\">");

--- a/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
@@ -32,6 +32,7 @@ public class NicknameServlet extends HttpServlet {
     UserService userService = UserServiceFactory.getUserService();
     if (userService.isUserLoggedIn()) {
       String nickname = getUserNickname(userService.getCurrentUser().getUserId());
+      response.getWriter().println("<style>#comment-form {display:none;}</style>");
       out.println("<p>Set your nickname here:</p>");
       out.println("<form method=\"POST\" action=\"/nickname\">");
       out.println("<input name=\"nickname\" value=\"" + nickname + "\" />");
@@ -59,6 +60,7 @@ public class NicknameServlet extends HttpServlet {
     Entity entity = new Entity(USER_INFO, id);
     entity.setProperty(ID, id);
     entity.setProperty(NICKNAME, nickname);
+    System.out.println("nickname putt");
     // The put() function automatically inserts new data or updates existing data based on ID.
     datastore.put(entity);
 

--- a/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
@@ -17,6 +17,8 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/nickname")
 public class NicknameServlet extends HttpServlet {
   private static final String NICKNAME = "nickname";
+  private static final String ID = "id";
+  private static final String USER_INFO = "userInfo";
   
 
   @Override
@@ -48,13 +50,13 @@ public class NicknameServlet extends HttpServlet {
       return;
     }
 
-    String nickname = request.getParameter("nickname");
+    String nickname = request.getParameter(NICKNAME);
     String id = userService.getCurrentUser().getUserId();
 
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-    Entity entity = new Entity("UserInfo", id);
-    entity.setProperty("id", id);
-    entity.setProperty("nickname", nickname);
+    Entity entity = new Entity(USER_INFO, id);
+    entity.setProperty(ID, id);
+    entity.setProperty(NICKNAME, nickname);
     // The put() function automatically inserts new data or updates existing data based on ID
     datastore.put(entity);
 
@@ -67,14 +69,14 @@ public class NicknameServlet extends HttpServlet {
   private String getUserNickname(String id) {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Query query =
-        new Query("UserInfo")
-            .setFilter(new Query.FilterPredicate("id", Query.FilterOperator.EQUAL, id));
+        new Query(USER_INFO)
+            .setFilter(new Query.FilterPredicate(ID, Query.FilterOperator.EQUAL, id));
     PreparedQuery results = datastore.prepare(query);
     Entity entity = results.asSingleEntity();
     if (entity == null) {
       return "";
     }
-    String nickname = (String) entity.getProperty("nickname");
+    String nickname = (String) entity.getProperty(NICKNAME);
     return nickname;
   }
 }

--- a/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
@@ -45,7 +45,7 @@ public class NicknameServlet extends HttpServlet {
       return;
     }
 
-    String nickname = getUserNickname(this.userService.getCurrentUser().getUserId()).orElse("");
+    String nickname = userNickname(this.userService.getCurrentUser().getUserId()).orElse("");
     response.getWriter().println("<style>#comment-form {display:none;}</style>");
     out.println("<p>Set your nickname here:</p>");
     out.println("<form method=\"POST\" action=\"/nickname\">");
@@ -76,9 +76,11 @@ public class NicknameServlet extends HttpServlet {
     response.sendRedirect(BOTTOM_OF_PAGE);
   }
 
-  /** Returns an Optional object containing the nickname of the user with {@code id},
-   * or an empty Optional if the user has not set a nickname. */
-  private Optional<String> getUserNickname(String id) {
+  /** 
+   * Returns the nickname of the user with {@code id}. If the user has not set a 
+   * nickname then returns {@code Optiona.empty()}. 
+   */
+  private Optional<String> userNickname(String id) {
     this.datastore = DatastoreServiceFactory.getDatastoreService();
     Query query =
         new Query(USER_INFO)

--- a/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
@@ -30,19 +30,19 @@ public class NicknameServlet extends HttpServlet {
     out.println("<h1>Set Nickname</h1>");
 
     UserService userService = UserServiceFactory.getUserService();
-    if (userService.isUserLoggedIn()) {
-      String nickname = getUserNickname(userService.getCurrentUser().getUserId());
-      response.getWriter().println("<style>#comment-form {display:none;}</style>");
-      out.println("<p>Set your nickname here:</p>");
-      out.println("<form method=\"POST\" action=\"/nickname\">");
-      out.println("<input name=\"nickname\" value=\"" + nickname + "\" />");
-      out.println("<br/>");
-      out.println("<button>Submit</button>");
-      out.println("</form>");
-    } else {
+    if (!userService.isUserLoggedIn()) {
       String loginUrl = userService.createLoginURL("/nickname");
       out.println("<p>Login <a href=\"" + loginUrl + "\">here</a>.</p>");
+      return;
     }
+    String nickname = getUserNickname(userService.getCurrentUser().getUserId());
+    response.getWriter().println("<style>#comment-form {display:none;}</style>");
+    out.println("<p>Set your nickname here:</p>");
+    out.println("<form method=\"POST\" action=\"/nickname\">");
+    out.println("<input name=\"nickname\" value=\"" + nickname + "\" />");
+    out.println("<br/>");
+    out.println("<button>Submit</button>");
+    out.println("</form>");
   }
 
   @Override

--- a/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
@@ -60,7 +60,6 @@ public class NicknameServlet extends HttpServlet {
     Entity entity = new Entity(USER_INFO, id);
     entity.setProperty(ID, id);
     entity.setProperty(NICKNAME, nickname);
-    System.out.println("nickname putt");
     // The put() function automatically inserts new data or updates existing data based on ID.
     datastore.put(entity);
 

--- a/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
@@ -38,7 +38,6 @@ public class NicknameServlet extends HttpServlet {
     PrintWriter out = response.getWriter();
     out.println("<h1>Set Nickname</h1>");
 
-    this.userService = UserServiceFactory.getUserService();
     if (!this.userService.isUserLoggedIn()) {
       String loginUrl = userService.createLoginURL("/nickname");
       out.println("<p>Login <a href=\"" + loginUrl + "\">here</a>.</p>");
@@ -57,7 +56,6 @@ public class NicknameServlet extends HttpServlet {
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    this.userService = UserServiceFactory.getUserService();
     if (!this.userService.isUserLoggedIn()) {
       response.sendRedirect("/nickname");
       return;
@@ -65,8 +63,6 @@ public class NicknameServlet extends HttpServlet {
 
     String nickname = request.getParameter(NICKNAME);
     String id = this.userService.getCurrentUser().getUserId();
-
-    this.datastore = DatastoreServiceFactory.getDatastoreService();
     Entity entity = new Entity(USER_INFO, id);
     entity.setProperty(ID, id);
     entity.setProperty(NICKNAME, nickname);
@@ -81,7 +77,6 @@ public class NicknameServlet extends HttpServlet {
    * nickname then returns {@code Optiona.empty()}. 
    */
   private Optional<String> userNickname(String id) {
-    this.datastore = DatastoreServiceFactory.getDatastoreService();
     Query query =
         new Query(USER_INFO)
             .setFilter(new Query.FilterPredicate(ID, Query.FilterOperator.EQUAL, id));

--- a/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
@@ -19,6 +19,8 @@ public class NicknameServlet extends HttpServlet {
   private static final String NICKNAME = "nickname";
   private static final String ID = "id";
   private static final String USER_INFO = "userInfo";
+
+  private static final String BOTTOM_OF_PAGE = "/index.html#connect-container";
   
 
   @Override
@@ -57,10 +59,10 @@ public class NicknameServlet extends HttpServlet {
     Entity entity = new Entity(USER_INFO, id);
     entity.setProperty(ID, id);
     entity.setProperty(NICKNAME, nickname);
-    // The put() function automatically inserts new data or updates existing data based on ID
+    // The put() function automatically inserts new data or updates existing data based on ID.
     datastore.put(entity);
 
-    response.sendRedirect("/");
+    response.sendRedirect(BOTTOM_OF_PAGE);
   }
 
   /**

--- a/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
@@ -68,7 +68,8 @@ public class NicknameServlet extends HttpServlet {
     response.sendRedirect(BOTTOM_OF_PAGE);
   }
 
-  /** Returns the nickname of the user with id, or null if the user has not set a nickname. */
+  /** Returns an Optional object containing the nickname of the user with {@code id},
+   * or an empty Optional if the user has not set a nickname. */
   private Optional<String> getUserNickname(String id) {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Query query =

--- a/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
+++ b/portfolio/src/main/java/com/google/sps/servlets/NicknameServlet.java
@@ -1,0 +1,78 @@
+package com.google.sps.servlets;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.PreparedQuery;
+import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.users.UserService;
+import com.google.appengine.api.users.UserServiceFactory;
+import java.io.IOException;
+import java.io.PrintWriter;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/nickname")
+public class NicknameServlet extends HttpServlet {
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    response.setContentType("text/html");
+    PrintWriter out = response.getWriter();
+    out.println("<h1>Set Nickname</h1>");
+
+    UserService userService = UserServiceFactory.getUserService();
+    if (userService.isUserLoggedIn()) {
+      String nickname = getUserNickname(userService.getCurrentUser().getUserId());
+      out.println("<p>Set your nickname here:</p>");
+      out.println("<form method=\"POST\" action=\"/nickname\">");
+      out.println("<input name=\"nickname\" value=\"" + nickname + "\" />");
+      out.println("<br/>");
+      out.println("<button>Submit</button>");
+      out.println("</form>");
+    } else {
+      String loginUrl = userService.createLoginURL("/nickname");
+      out.println("<p>Login <a href=\"" + loginUrl + "\">here</a>.</p>");
+    }
+  }
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    UserService userService = UserServiceFactory.getUserService();
+    if (!userService.isUserLoggedIn()) {
+      response.sendRedirect("/nickname");
+      return;
+    }
+
+    String nickname = request.getParameter("nickname");
+    String id = userService.getCurrentUser().getUserId();
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Entity entity = new Entity("UserInfo", id);
+    entity.setProperty("id", id);
+    entity.setProperty("nickname", nickname);
+    // The put() function automatically inserts new data or updates existing data based on ID
+    datastore.put(entity);
+
+    response.sendRedirect("/home");
+  }
+
+  /**
+   * Returns the nickname of the user with id, or empty String if the user has not set a nickname.
+   */
+  private String getUserNickname(String id) {
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Query query =
+        new Query("UserInfo")
+            .setFilter(new Query.FilterPredicate("id", Query.FilterOperator.EQUAL, id));
+    PreparedQuery results = datastore.prepare(query);
+    Entity entity = results.asSingleEntity();
+    if (entity == null) {
+      return "";
+    }
+    String nickname = (String) entity.getProperty("nickname");
+    return nickname;
+  }
+}

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -164,7 +164,7 @@
                 <option value="Longest First">Longest First</option>
             </select>
         </div>
-        <form action="/data" method="POST">
+        <form action="/data" method="POST" id="comment-form">
             <div id="form-elements-container">
             <div>
                 <label for="comment-input"> Enter a comment here:</label><br>

--- a/portfolio/src/main/webapp/index.html
+++ b/portfolio/src/main/webapp/index.html
@@ -152,7 +152,6 @@
 
       <div class="flex-container">
         <div>
-            <button onclick="deleteAllComments();">Delete all Comments</button>
             <select name="amount" id="amount" onchange="getMessageFromJSON(false);">
                 <option value="5">5</option>
                 <option value="10">10</option>

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -274,7 +274,14 @@ function fetchLogin() {
  * Appends {@code text} to login div container.
  */
 function appendToLogin(text) {
+  console.log("appendtologin");
   const login = document.getElementById('login');
   login.innerHTML = text;
 }
 
+//TODO: Simplify this method.
+function changeNickname() {
+  fetch('/nickname')
+      .then(response => response.text())
+      .then(appendToLogin);
+}

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -273,7 +273,6 @@ function fetchLogin() {
  * Appends {@code text} to login div container.
  */
 function appendToLogin(text) {
-  console.log("appendtologin");
   const login = document.getElementById('login');
   login.innerHTML = text;
 }

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -224,7 +224,7 @@ function appendTextToList(comment, ulElement) {
   const date = (new Date(comment.timestamp)).toString()
       .substring(0, END_OF_TIMESTAMP);
 
-  appendPTagToContainer(comment.email, infoDivElement);
+  appendPTagToContainer(comment.nickname, infoDivElement);
   appendPTagToContainer(comment.name, infoDivElement);
   appendPTagToContainer(date, infoDivElement);
 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -277,7 +277,10 @@ function appendToLogin(text) {
   login.innerHTML = text;
 }
 
-//TODO: Simplify this method.
+/** 
+ * Fetches the HTML form from /nickname and appends
+ * it to the DOM.
+ */
 function changeNickname() {
   fetch('/nickname')
       .then(response => response.text())


### PR DESCRIPTION
Instead of showing the user's email next to the comment, the user's nickname is displayed. Users will not be able to write comments until they submit a nickname. Additionally, users also have the option of updating their nickname. 

Comment box hidden until the user sets a nickname: https://screenshot.googleplex.com/mP9ZcxUwPLg.png
Comment with one nickname: https://screenshot.googleplex.com/cj4qdGqnnWu.png
Comment with another nickname: https://screenshot.googleplex.com/ahBidoFrB4L.png