### PR TITLE
Implement query() to return a list of available time ranges.

### DIFF
--- a/portfolio/src/main/webapp/style.css
+++ b/portfolio/src/main/webapp/style.css
@@ -129,13 +129,6 @@ h2 {
   width: 100%;
 }
 
-.hidden {
-  background-color: gainsboro; 
-  bottom: 30%;
-  font-size: 1vw;
-  visibility: hidden;
-}
-
 .overlay {
   background-color: white;
   bottom: 15%;
@@ -147,6 +140,13 @@ h2 {
   position: absolute;
   text-align: center;
   z-index: 2;
+}
+
+.hidden {
+  background-color: gainsboro; 
+  bottom: 30%;
+  font-size: 1vw;
+  visibility: hidden;
 }
 
 #overlay-uni {

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -43,6 +43,11 @@ public final class FindMeetingQuery {
     for (Event event : events) {
       // Ignores this event's time range if the people attending this event are 
       // not attending the requested meeting. 
+      Set<String> eventAttendees = new HashSet<String>(event.getAttendees());
+      eventAttendees.retainAll(attendees);
+      if (eventAttendees.isEmpty()) {
+        continue;
+      }
 
       TimeRange time = event.getWhen();
       // Skips this event because it ended before or at the same time as

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -57,9 +57,10 @@ public final class FindMeetingQuery {
       if (time.end() <= currentEndTime) {
         continue;
       }
-      if ((time.start() <= currentEndTime) || (request.getDuration() > (time.start() - currentEndTime)) {
-        // Handles events starting before but ending after the currentEndTime and the case where the request
-        // meeeting duration is longer than the time gap.
+      if ((time.start() <= currentEndTime) || 
+          (request.getDuration() > (time.start() - currentEndTime)) {
+        // Handles events starting before but ending after the currentEndTime and the case 
+        // where the request meeeting duration is longer than the time gap.
         currentEndTime = time.end();
         continue;
       }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -15,9 +15,32 @@
 package com.google.sps;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
+/** Finds potential meeting times. */
 public final class FindMeetingQuery {
+
+  /**
+   * Returns available TimeRanges for the {@code request} given {@code events}, a Collection of
+   * all events so far. 
+   */
   public Collection<TimeRange> query(Collection<Event> events, MeetingRequest request) {
-    throw new UnsupportedOperationException("TODO: Implement this method.");
+    Collection<TimeRange> times = new ArrayList<>();
+    Collection<String> attendees = request.getAttendees();
+    
+    if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
+      // If the event is longer than a day, no time slots are available to book a meeting.
+      return times; 
+    } else if (attendees.size() == 0) {
+      // If there are no attendees, the entire day is available to book a meeting.
+      times.add(TimeRange.WHOLE_DAY);
+      return times;
+    }
+
+
+    return times;
   }
 }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -34,11 +34,13 @@ public final class FindMeetingQuery {
     if (request.getDuration() > TimeRange.WHOLE_DAY.duration()) {
       // If the event is longer than a day, no time slots are available to book a meeting.
       return times; 
-    } else if (attendees.size() == 0) {
+    }
+    if (attendees.size() == 0) {
       // If there are no attendees, the entire day is available to book a meeting.
       times.add(TimeRange.WHOLE_DAY);
       return times;
     }
+
     int currentEndTime = TimeRange.START_OF_DAY;
     for (Event event : events) {
       // Ignores this event's time range if the people attending this event are 
@@ -54,13 +56,10 @@ public final class FindMeetingQuery {
       // the latest event.
       if (time.end() <= currentEndTime) {
         continue;
-      } else if (time.start() <= currentEndTime) {
-        // Handles events starting before but ending after the currentEndTime.
-        currentEndTime = time.end();
-        continue;
-      }else if (request.getDuration() > (time.start() - currentEndTime)) {
-        // Does not add the time range if the time gap is smaller than the duration of
-        // the requested meeting.
+      }
+      if ((time.start() <= currentEndTime) || (request.getDuration() > (time.start() - currentEndTime)) {
+        // Handles events starting before but ending after the currentEndTime and the case where the request
+        // meeeting duration is longer than the time gap.
         currentEndTime = time.end();
         continue;
       }

--- a/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
+++ b/walkthroughs/week-5-tdd/project/src/main/java/com/google/sps/FindMeetingQuery.java
@@ -75,7 +75,6 @@ public final class FindMeetingQuery {
           TimeRange.END_OF_DAY, true);
       times.add(latestTimeRange);
     }
-
     return times;
   }
 }


### PR DESCRIPTION
Given a list of all existing calendar events and a meeting request object, query() returns the available time ranges in which the requested meeting can take place. It also takes into consideration overlapping events and the availability of all the attendees when suggesting time ranges.

Screenshot of what this looks like on the front-end: https://screenshot.googleplex.com/k7F2NBeRX8D.png