### PR TITLE
Color the comment background based on its sentiment score.

### DIFF
--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -251,7 +251,7 @@ function appendTextToList(comment, ulElement) {
  * green or red based on {@code score}.
  */
 function updateBackgroundColorBasedOnSentiment(score, elementToColor) {
-  // The original sentiment score is from -1 to 1 so shifting the score
+  // The original sentiment score is from -1 to 1, so shifting the score
   // by 1 and dividing by 2 will yield a ratio where 1 is positive and 0
   // is negative.
   const scoreAsRatio = (score + 1) / 2 

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -241,7 +241,6 @@ function appendTextToList(comment, ulElement) {
   liElement.appendChild(createCommentImage(comment.imageUrl));
 
   updateBackgroundColorBasedOnSentiment(comment.sentiment, liElement);
-  
   // Separates each comment with a horizontal bar.
   liElement.appendChild(document.createElement('hr'));
   ulElement.appendChild(liElement);

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -240,11 +240,26 @@ function appendTextToList(comment, ulElement) {
   textPElement.className = COMMENT_CLASS;
   liElement.appendChild(createCommentImage(comment.imageUrl));
 
-  const sentimentPElement = appendPTagToContainer(comment.sentiment, liElement);
+  updateBackgroundColorBasedOnSentiment(comment.sentiment, liElement);
   
   // Separates each comment with a horizontal bar.
   liElement.appendChild(document.createElement('hr'));
   ulElement.appendChild(liElement);
+}
+
+/**
+ * Updates the background color of {@code elementToColor} to be a variant of 
+ * green or red based on {@code score}.
+ */
+function updateBackgroundColorBasedOnSentiment(score, elementToColor) {
+  // The original sentiment score is from -1 to 1 so shifting the score
+  // by 1 and dividing by 2 will yield the ratio.
+  const scoreAsRatio = (score + 1) / 2 
+  // In HSL, 120 is green and 0 is red so a positive score will be green.
+  let HSLColor = scoreAsRatio * 120
+  // The second parameter in HSL indicates the saturation and the third
+  // parameter indicates the lightness.
+  elementToColor.style.backgroundColor = "hsl(" + HSLColor + ", 80%, 80%)"
 }
 
 /**

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -257,7 +257,7 @@ function updateBackgroundColorBasedOnSentiment(score, elementToColor) {
   // is negative.
   const scoreAsRatio = (score + 1) / 2 
   // In HSL, 120 is green and 0 is red so a positive score will be green.
-  let HSLColor = scoreAsRatio * 120
+  const HSLColor = scoreAsRatio * 120
   // The second parameter in HSL indicates the saturation and the third
   // parameter indicates the lightness.
   elementToColor.style.backgroundColor = "hsl(" + HSLColor + ", 80%, 80%)"

--- a/portfolio/src/main/webapp/script.js
+++ b/portfolio/src/main/webapp/script.js
@@ -253,7 +253,8 @@ function appendTextToList(comment, ulElement) {
  */
 function updateBackgroundColorBasedOnSentiment(score, elementToColor) {
   // The original sentiment score is from -1 to 1 so shifting the score
-  // by 1 and dividing by 2 will yield the ratio.
+  // by 1 and dividing by 2 will yield a ratio where 1 is positive and 0
+  // is negative.
   const scoreAsRatio = (score + 1) / 2 
   // In HSL, 120 is green and 0 is red so a positive score will be green.
   let HSLColor = scoreAsRatio * 120


### PR DESCRIPTION
Instead of displaying the sentiment score, the score is used to calculate how red or green the comment background should be. Green indicates that the comment is positive while red indicates that the comment is negative. Yellow indicates that the comment is neutral.

Comments with colored background: https://screenshot.googleplex.com/9N51snW6ip2.png